### PR TITLE
Fix test precision

### DIFF
--- a/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
+++ b/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
@@ -1,41 +1,42 @@
 Class {
-	#name : #AIAbstractLinearModelTest,
-	#superclass : #TestCase,
+	#name : 'AIAbstractLinearModelTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'model'
 	],
-	#category : #'AI-LinearModels-Tests'
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 AIAbstractLinearModelTest class >> isAbstract [ 
 ^self == AIAbstractLinearModelTest 
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 AIAbstractLinearModelTest >> regression [
 
 	^ self subclassResponsibility
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 AIAbstractLinearModelTest >> setUp [
 
 	super setUp.
 	model := self regression
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testDivergingException [
 	^ self subclassResponsibility
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testExactFitSingleVariable [
 	^ self subclassResponsibility
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testInconsistentFitOnDimension [
 
 	| input output |
@@ -45,7 +46,7 @@ AIAbstractLinearModelTest >> testInconsistentFitOnDimension [
 	self should: [ model fitX: input y: output ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testInitializeWeightsToZeroOfSize [
 
 	| expectedInitWeigths |
@@ -55,13 +56,13 @@ AIAbstractLinearModelTest >> testInitializeWeightsToZeroOfSize [
 	self assert: model weights equals: expectedInitWeigths   
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testPerformedIterationsIsInitialized [
 
 	self assert: model performedIterations equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testPredictionWithNonFittedModel [
 
 	| input output |
@@ -70,7 +71,7 @@ AIAbstractLinearModelTest >> testPredictionWithNonFittedModel [
 	self should: [ output := model predict: input ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AIAbstractLinearModelTest >> testWeightedSumOf [
 
 	model bias: 2.

--- a/src/AI-LinearModels-Tests/AILinearRegressionFixture.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionFixture.class.st
@@ -3,24 +3,25 @@ I am a fixture with a small and simple example for linear regression.
 I provide input matrix X and expected output vector y.
 "
 Class {
-	#name : #AILinearRegressionFixture,
-	#superclass : #Object,
+	#name : 'AILinearRegressionFixture',
+	#superclass : 'Object',
 	#instVars : [
 		'bias',
 		'inputMatrix',
 		'outputVector',
 		'weights'
 	],
-	#category : #'AI-LinearModels-Tests'
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionFixture >> bias [
 
 	^ bias
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 AILinearRegressionFixture >> initialize [
 
 	| function |
@@ -36,19 +37,19 @@ AILinearRegressionFixture >> initialize [
 	
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionFixture >> inputMatrix [
 
 	^ inputMatrix
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionFixture >> outputVector [
 
 	^ outputVector
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionFixture >> weights [
 
 	^ weights

--- a/src/AI-LinearModels-Tests/AILinearRegressionLeastSquaresTest.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionLeastSquaresTest.class.st
@@ -1,40 +1,41 @@
 Class {
-	#name : #AILinearRegressionLeastSquaresTest,
-	#superclass : #AILinearRegressionTest,
-	#category : #'AI-LinearModels-Tests'
+	#name : 'AILinearRegressionLeastSquaresTest',
+	#superclass : 'AILinearRegressionTest',
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AILinearRegressionLeastSquaresTest >> regression [
 
 	^ AILinearRegressionLeastSquares new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresTest >> testInitializeWeightsToZeroOfSize [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresTest >> testLearningRateIsInitialized [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresTest >> testMaxIterationsIsInitialized [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresTest >> testPerformedIterationsIsInitialized [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresTest >> testWeightDerivativeforXCostDerivative [
 
 	self skip

--- a/src/AI-LinearModels-Tests/AILinearRegressionLeastSquaresVanillaTest.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionLeastSquaresVanillaTest.class.st
@@ -1,28 +1,29 @@
 Class {
-	#name : #AILinearRegressionLeastSquaresVanillaTest,
-	#superclass : #AILinearRegressionLeastSquaresTest,
-	#category : #'AI-LinearModels-Tests'
+	#name : 'AILinearRegressionLeastSquaresVanillaTest',
+	#superclass : 'AILinearRegressionLeastSquaresTest',
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AILinearRegressionLeastSquaresVanillaTest >> regression [
 
 	^ AILinearRegressionLeastSquaresVanilla new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresVanillaTest >> testBiasDerivative [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresVanillaTest >> testCostDerivativeActual [
 
 	self skip
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionLeastSquaresVanillaTest >> testWeightedSumOf [
 
 	self skip

--- a/src/AI-LinearModels-Tests/AILinearRegressionTest.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionTest.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #AILinearRegressionTest,
-	#superclass : #AIAbstractLinearModelTest,
+	#name : 'AILinearRegressionTest',
+	#superclass : 'AIAbstractLinearModelTest',
 	#instVars : [
 		'fixture'
 	],
-	#category : #'AI-LinearModels-Tests'
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AILinearRegressionTest >> regression [
 
 	^ AILinearRegression new
@@ -16,7 +17,7 @@ AILinearRegressionTest >> regression [
 		yourself
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 AILinearRegressionTest >> setUp [
 
 	super setUp.
@@ -25,7 +26,7 @@ AILinearRegressionTest >> setUp [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testBiasAlmostEqual [
 
 	model
@@ -35,7 +36,7 @@ AILinearRegressionTest >> testBiasAlmostEqual [
 	self assert: model bias closeTo: fixture bias precision: 0.001
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testBiasDerivative [
 
 	self
@@ -43,7 +44,7 @@ AILinearRegressionTest >> testBiasDerivative [
 		equals: 4.5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testCostDerivativeActual [
 
 	self
@@ -55,7 +56,7 @@ AILinearRegressionTest >> testCostDerivativeActual [
 		equals: #(1 2 3)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testDivergingException [
 
 	"Training the model with non-sense, completely unproportioned data and with a very high learning rate to raise the diverging exception."
@@ -71,7 +72,7 @@ AILinearRegressionTest >> testDivergingException [
 	self should: [model fitX: input y: output] raise: ModelStartingToDivergeException
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testExactFitSingleVariable [
 
 	| newInput expectedOutput actualOutput |
@@ -83,7 +84,7 @@ AILinearRegressionTest >> testExactFitSingleVariable [
 	actualOutput with: expectedOutput do: [ :actual :expected | self assert: actual closeTo: expected precision: 0.001 ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testWeightDerivativeforXCostDerivative [
 	
 	self
@@ -91,7 +92,7 @@ AILinearRegressionTest >> testWeightDerivativeforXCostDerivative [
 		equals: #( 37.5 45 52.5 )
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTest >> testWeightsAlmostEqual [
 
 	model
@@ -99,5 +100,5 @@ AILinearRegressionTest >> testWeightsAlmostEqual [
 		y: fixture outputVector.
 
 	fixture weights with: model weights do: [ :expected :actual |
-		self assert: actual closeTo: expected ]
+		self assert: actual closeTo: expected precision: 0.0001 ]
 ]

--- a/src/AI-LinearModels-Tests/AILinearRegressionTrivialFixture.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionTrivialFixture.class.st
@@ -2,8 +2,8 @@
 This is a simple and trivial fixture that we did to compute things manually
 "
 Class {
-	#name : #AILinearRegressionTrivialFixture,
-	#superclass : #Object,
+	#name : 'AILinearRegressionTrivialFixture',
+	#superclass : 'Object',
 	#instVars : [
 		'initialBias',
 		'initialWeights',
@@ -17,58 +17,59 @@ Class {
 		'expectedBiasAtFirstIteration',
 		'expectedPredictionBeforeLearning'
 	],
-	#category : #'AI-LinearModels-Tests'
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedBiasAtFirstIteration [
 
 	^ expectedBiasAtFirstIteration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedBiasDerivativeAtFirstIteration [
 
 	^ expectedBiasDerivativeAtFirstIteration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedCostBeforeLearning [
 
 	^ expectedCostBeforeLearning
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedPredictionBeforeLearning [
 
 	^ expectedPredictionBeforeLearning
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedWeightDerivativeAtFirstIterarion [
 
 	^ expectedWeightDerivativeAtFirstIterarion
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> expectedWeightsAtFirstIteration [
 
 	^ expectedWeightsAtFirstIteration
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> initialBias [
 
 	^ initialBias
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> initialWeights [
 
 	^ initialWeights
 ]
 
-{ #category : #initialization }
+{ #category : 'initialization' }
 AILinearRegressionTrivialFixture >> initialize [
 
 	super initialize.
@@ -87,19 +88,19 @@ AILinearRegressionTrivialFixture >> initialize [
 	expectedBiasAtFirstIteration := 1/15
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> inputMatrix [
 
 	^ inputMatrix
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> learningRate [
 
 	^ learningRate
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 AILinearRegressionTrivialFixture >> outputVector [
 
 	^ outputVector

--- a/src/AI-LinearModels-Tests/AILinearRegressionTrivialTest.class.st
+++ b/src/AI-LinearModels-Tests/AILinearRegressionTrivialTest.class.st
@@ -1,14 +1,15 @@
 Class {
-	#name : #AILinearRegressionTrivialTest,
-	#superclass : #TestCase,
+	#name : 'AILinearRegressionTrivialTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'model',
 		'fixture'
 	],
-	#category : #'AI-LinearModels-Tests'
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 AILinearRegressionTrivialTest >> setUp [
 
 	super setUp.
@@ -21,7 +22,7 @@ AILinearRegressionTrivialTest >> setUp [
 		learningRate: fixture learningRate
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testCostBeforeLearning [
 
 	| cost |
@@ -29,7 +30,7 @@ AILinearRegressionTrivialTest >> testCostBeforeLearning [
 	self assert: cost equals: fixture expectedCostBeforeLearning 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testExpectedBiasAtFirstIteration [
 
 	model updateWeightsForX: fixture inputMatrix y: fixture outputVector.
@@ -37,7 +38,7 @@ AILinearRegressionTrivialTest >> testExpectedBiasAtFirstIteration [
 	self assert: model bias closeTo: fixture expectedBiasAtFirstIteration
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testExpectedBiasDerivativeAtFirstIteration [
 
 	| predictedOutputVector costDerivative biasDerivative |
@@ -49,7 +50,7 @@ AILinearRegressionTrivialTest >> testExpectedBiasDerivativeAtFirstIteration [
 	self assert: biasDerivative equals: fixture expectedBiasDerivativeAtFirstIteration
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testExpectedWeightDerivateAtFirstIteration [
 
 	| predictedOutputVector costDerivative weightDerivative |
@@ -60,7 +61,7 @@ AILinearRegressionTrivialTest >> testExpectedWeightDerivateAtFirstIteration [
 	self assert: weightDerivative equals: fixture expectedWeightDerivativeAtFirstIterarion
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testExpectedWeightsAtFirstIteration [
 
 	model updateWeightsForX: fixture inputMatrix y: fixture outputVector.
@@ -70,7 +71,7 @@ AILinearRegressionTrivialTest >> testExpectedWeightsAtFirstIteration [
 		do: [ :real : expected | self assert: real closeTo: expected ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILinearRegressionTrivialTest >> testPredictionBeforeLearning [
 
 	| prediction |

--- a/src/AI-LinearModels-Tests/AILogisticRegressionTest.class.st
+++ b/src/AI-LinearModels-Tests/AILogisticRegressionTest.class.st
@@ -2,24 +2,25 @@
 An AILogisticRegressionTest is a test class for testing the behavior of AILogisticRegression
 "
 Class {
-	#name : #AILogisticRegressionTest,
-	#superclass : #AIAbstractLinearModelTest,
-	#category : #'AI-LinearModels-Tests'
+	#name : 'AILogisticRegressionTest',
+	#superclass : 'AIAbstractLinearModelTest',
+	#category : 'AI-LinearModels-Tests',
+	#package : 'AI-LinearModels-Tests'
 }
 
-{ #category : #defaults }
+{ #category : 'defaults' }
 AILogisticRegressionTest >> generateRandomNumber: random between: lowerBound and: higherBound [
 
 	^ lowerBound + (random next * (higherBound - lowerBound))
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 AILogisticRegressionTest >> regression [
 
 	^AILogisticRegression new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILogisticRegressionTest >> testDivergingException [
 
 	"Training the model with non-sense, completely unproportioned data and with a very high learning rate to raise the diverging exception."
@@ -38,7 +39,7 @@ AILogisticRegressionTest >> testDivergingException [
 	self should: [model fitX: input y: output] raise: ModelStartingToDivergeException
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILogisticRegressionTest >> testExactFitSingleVariable [
 
 	| output newInput expectedOutput actualOutput inputPositive inputNegative input |
@@ -72,7 +73,7 @@ AILogisticRegressionTest >> testExactFitSingleVariable [
 		do: [ :actual :expected | self assert: actual equals: expected ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 AILogisticRegressionTest >> testPredictProbabilities [
 
 	| output newInput expectedOutput actualOutput inputPositive inputNegative input actualOutputPositive actualOutputNegative |

--- a/src/AI-LinearModels-Tests/package.st
+++ b/src/AI-LinearModels-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'AI-LinearModels-Tests' }
+Package { #name : 'AI-LinearModels-Tests' }


### PR DESCRIPTION
Use a better fitted precision for the test `testWeightsAlmostEqual` that was broken with the default float precision.